### PR TITLE
Google GeminiPro support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 *~
 target/
 .idea
+examples/secrets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ lazy_static = "1.4.0"
 base64 = "0.13.0"
 tokio = { version = "1.19.2", features = ["full"] }
 async-trait = "0.1.66"
+yup-oauth2 = "8.3.2"
+futures = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "allms"
-version = "0.4.1"
-edition = "2021"
+version = "0.5.0"
+edition = "2024"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",
     "Dario Lencina <dario@neferdata.com>",
 ]
-keywords = ["openai", "mistral", "anthropic", "ai", "assistant"]
+keywords = ["openai", "mistral", "anthropic", "gemini", "assistant"]
 description = "One Library to rule them aLLMs"
 license = "MIT"
 repository = "https://github.com/neferdata/allms.git"
 readme = "README.md"
-categories = ["ai", "openai", "anthropic", "mistral", "assistant"]
+categories = ["openai", "anthropic", "mistral", "gemini", "assistant"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "allms"
 version = "0.5.0"
-edition = "2024"
+edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",
     "Dario Lencina <dario@neferdata.com>",

--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -88,7 +88,7 @@ async fn main() {
         .unwrap();
     let google_token_str = &google_token.token().unwrap();
 
-    let gemini_completion = Completions::new(model, &google_token_str, None, None);
+    let gemini_completion = Completions::new(model, google_token_str, None, None);
 
     match gemini_completion
         .get_answer::<TranslationResponse>(instructions)

--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
-use yup_oauth2::{read_service_account_key, ServiceAccountAuthenticator};
+//use yup_oauth2::{read_service_account_key, ServiceAccountAuthenticator};
 
 use allms::{
     llm_models::{AnthropicModels, GoogleModels, MistralModels, OpenAIModels},
@@ -69,10 +69,14 @@ async fn main() {
     }
 
     // Get answer using Google GeminiPro
-    let model = GoogleModels::GeminiProVertex; // Choose the model
+
+    /*
+    // ********** Code to obtain auth token for Vertex AI API using a GCP service account and key
+    let model = GoogleModels::GeminiProVertex;
 
     // To authenticate Google we need to use a key associated with a GCP service account with correct grants
     // Load your service account key from a file or an environment variable
+    // Remember to turn on the yup_oauth2 imports
     let service_account_key = read_service_account_key("secrets/gcp_sa_key.json")
         .await
         .unwrap();
@@ -87,8 +91,17 @@ async fn main() {
         .await
         .unwrap();
     let google_token_str = &google_token.token().unwrap();
+    // ********** End Google Vertex AI authentication code
+    */
 
-    let gemini_completion = Completions::new(model, google_token_str, None, None);
+    // ********** Code for using API Key from Google AI Studio
+    let model = GoogleModels::GeminiPro;
+
+    let google_token_str: String =
+        std::env::var("GOOGLE_AI_STUDIO_API_KEY").expect("GOOGLE_AI_STUDIO_API_KEY not set");
+    // ********** End Google AI Studio authentication code
+
+    let gemini_completion = Completions::new(model, &google_token_str, None, None);
 
     match gemini_completion
         .get_answer::<TranslationResponse>(instructions)

--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -1,9 +1,10 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
+use yup_oauth2::{read_service_account_key, ServiceAccountAuthenticator};
 
 use allms::{
-    llm_models::{AnthropicModels, MistralModels, OpenAIModels},
+    llm_models::{AnthropicModels, GoogleModels, MistralModels, OpenAIModels},
     Completions,
 };
 
@@ -21,7 +22,7 @@ async fn main() {
 
     // Example context and instructions
     let instructions =
-        "Translate this exact English sentence to all the languages in the response type: \"Hi, how are you?\"";
+        "Translate the following English sentence to all the languages in the response type: Rust is best for working with LLMs";
 
     // Get answer using OpenAI
     let openai_api_key: String = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
@@ -60,11 +61,40 @@ async fn main() {
     let mistral_completion = Completions::new(model, &mistral_api_key, None, None);
 
     match mistral_completion
-        .debug()
         .get_answer::<TranslationResponse>(instructions)
         .await
     {
         Ok(response) => println!("Mistral response: {:?}", response),
+        Err(e) => eprintln!("Error: {:?}", e),
+    }
+
+    // Get answer using Google GeminiPro
+    let model = GoogleModels::GeminiProVertex; // Choose the model
+
+    // To authenticate Google we need to use a key associated with a GCP service account with correct grants
+    // Load your service account key from a file or an environment variable
+    let service_account_key = read_service_account_key("secrets/gcp_sa_key.json")
+        .await
+        .unwrap();
+
+    // Authenticate with your service account
+    let auth = ServiceAccountAuthenticator::builder(service_account_key)
+        .build()
+        .await
+        .unwrap();
+    let google_token = auth
+        .token(&["https://www.googleapis.com/auth/cloud-platform"])
+        .await
+        .unwrap();
+    let google_token_str = &google_token.token().unwrap();
+
+    let gemini_completion = Completions::new(model, &google_token_str, None, None);
+
+    match gemini_completion
+        .get_answer::<TranslationResponse>(instructions)
+        .await
+    {
+        Ok(response) => println!("Gemini response: {:?}", response),
         Err(e) => eprintln!("Error: {:?}", e),
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -25,9 +25,9 @@ lazy_static! {
     };
     pub(crate) static ref GOOGLE_GEMINI_API_URL: String = std::env::var("GOOGLE_GEMINI_API_URL")
         .unwrap_or(
-        "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent"
-            .to_string()
-    );
+            "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent"
+                .to_string()
+        );
 }
 
 //Generic OpenAI instructions

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -15,6 +15,21 @@ lazy_static! {
         .unwrap_or("https://api.mistral.ai/v1/chat/completions".to_string());
 }
 
+lazy_static! {
+    pub(crate) static ref GOOGLE_VERTEX_API_URL: String = {
+        let region = std::env::var("GOOGLE_REGION").unwrap_or("us-central1".to_string());
+        let project_id = std::env::var("GOOGLE_PROJECT_ID").expect("PROJECT_ID not set");
+
+        format!("https://{}-aiplatform.googleapis.com/v1/projects/{}/locations/{}/publishers/google/models/gemini-pro:streamGenerateContent?alt=sse",
+                region, project_id, region)
+    };
+    pub(crate) static ref GOOGLE_GEMINI_API_URL: String = std::env::var("GOOGLE_GEMINI_API_URL")
+        .unwrap_or(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:streamGenerateContent"
+            .to_string()
+    );
+}
+
 //Generic OpenAI instructions
 pub(crate) const OPENAI_BASE_INSTRUCTIONS: &str = r#"You are a computer function. You are expected to perform the following tasks:
 Step 1: Review and understand the 'instructions' from the *Instructions* section.

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -302,3 +302,75 @@ pub struct MistralAPICompletionsUsage {
     pub completion_tokens: usize,
     pub total_tokens: usize,
 }
+
+///Google GeminiPro API response deserialization structs
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProApiResp {
+    pub candidates: Vec<GoogleGeminiProCandidate>,
+    #[serde(rename = "usageMetadata")]
+    pub usage_metadata: Option<GoogleGeminiProUsageMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProCandidate {
+    pub content: GoogleGeminiProContent,
+    #[serde(rename = "finishReason")]
+    pub finish_reason: Option<String>,
+    #[serde(rename = "safetyRatings")]
+    pub safety_ratings: Option<Vec<GoogleGeminiProSafetyRating>>,
+    #[serde(rename = "citationMetadata")]
+    pub citation_metadata: Option<GoogleGeminiProCitationMetadata>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProContent {
+    pub parts: Vec<GoogleGeminiProPart>,
+    pub role: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProPart {
+    pub text: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProSafetyRating {
+    pub category: String,
+    pub probability: String,
+    pub blocked: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProCitationMetadata {
+    pub citations: Vec<GoogleGeminiProCitation>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProCitation {
+    #[serde(rename = "startIndex")]
+    pub start_index: i32,
+    #[serde(rename = "endIndex")]
+    pub end_index: i32,
+    pub uri: String,
+    pub title: Option<String>,
+    pub license: Option<String>,
+    #[serde(rename = "publicationDate")]
+    pub publication_date: Option<GoogleGeminiProDate>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProDate {
+    pub year: i32,
+    pub month: i32,
+    pub day: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GoogleGeminiProUsageMetadata {
+    #[serde(rename = "promptTokenCount")]
+    pub prompt_token_count: i32,
+    #[serde(rename = "candidatesTokenCount")]
+    pub candidates_token_count: i32,
+    #[serde(rename = "totalTokenCount")]
+    pub total_token_count: i32,
+}

--- a/src/llm_models/google.rs
+++ b/src/llm_models/google.rs
@@ -1,0 +1,183 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use futures::stream::StreamExt;
+use log::info;
+use reqwest::{header, Client};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::constants::{GOOGLE_GEMINI_API_URL, GOOGLE_VERTEX_API_URL};
+use crate::{
+    domain::{GoogleGeminiProApiResp, RateLimit},
+    llm_models::LLMModel,
+};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+//Google docs: https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemini
+pub enum GoogleModels {
+    GeminiPro,
+    GeminiProVertex,
+}
+
+#[async_trait(?Send)]
+impl LLMModel for GoogleModels {
+    fn as_str(&self) -> &'static str {
+        match self {
+            GoogleModels::GeminiPro | GoogleModels::GeminiProVertex => "gemini-pro",
+        }
+    }
+
+    fn default_max_tokens(&self) -> usize {
+        //https://cloud.google.com/vertex-ai/docs/generative-ai/learn/models
+        match self {
+            GoogleModels::GeminiPro | GoogleModels::GeminiProVertex => 32_000,
+        }
+    }
+
+    fn get_endpoint(&self) -> String {
+        //The URL requires GOOGLE_REGION and GOOGLE_PROJECT_ID env variables defined to work.
+        //If not set GOOGLE_REGION will default to 'us-central1' but GOOGLE_PROJECT_ID needs to be defined.
+        match self {
+            GoogleModels::GeminiPro => GOOGLE_GEMINI_API_URL.to_string(),
+            GoogleModels::GeminiProVertex => GOOGLE_VERTEX_API_URL.to_string(),
+        }
+    }
+
+    //This method prepares the body of the API call for different models
+    fn get_body(
+        &self,
+        instructions: &str,
+        json_schema: &Value,
+        function_call: bool,
+        _max_tokens: &usize,
+        temperature: &u32,
+    ) -> serde_json::Value {
+        //Prepare the 'messages' part of the body
+        let base_instructions_json = json!({
+            "text": self.get_base_instructions(Some(function_call))
+        });
+
+        let schema_string = serde_json::to_string(json_schema).unwrap_or_default();
+        let output_instructions_json =
+            json!({ "text": format!("'Output Json schema': {schema_string}") });
+
+        let user_instructions_json = json!({
+            "text": instructions,
+        });
+
+        let contents = json!({
+            "role": "user",
+            "parts": vec![
+                base_instructions_json,
+                output_instructions_json,
+                user_instructions_json,
+            ],
+        });
+
+        let generation_config = json!({
+            "temperature": temperature,
+        });
+
+        json!({
+            "contents": contents,
+            "generationConfig": generation_config,
+        })
+    }
+    /*
+     * This function leverages Mistral API to perform any query as per the provided body.
+     *
+     * It returns a String the Response object that needs to be parsed based on the self.model.
+     */
+    async fn call_api(
+        &self,
+        api_key: &str,
+        body: &serde_json::Value,
+        debug: bool,
+    ) -> Result<String> {
+        //Get the API url
+        let model_url = self.get_endpoint();
+
+        //Make the API call
+        let client = Client::new();
+
+        //Send request
+        let response = client
+            .post(model_url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .bearer_auth(api_key)
+            .json(&body)
+            .send()
+            .await?;
+
+        // Google API streams the results. We need to handle that
+        // Check if the API uses streaming
+        if response.status().is_success() {
+            let mut stream = response.bytes_stream();
+            let mut streamed_response = String::new();
+
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk?;
+
+                // Convert the chunk (Bytes) to a String
+                let mut chunk_str = String::from_utf8(chunk.to_vec()).map_err(|e| anyhow!(e))?;
+
+                // The chunk response starts with "data: " that needs to be remove
+                if chunk_str.starts_with("data: ") {
+                    // Remove the first 6 characters ("data: ")
+                    chunk_str = chunk_str[6..].to_string();
+                }
+
+                //Convert response chunk to struct representing expected response format
+                let gemini_response: GoogleGeminiProApiResp = serde_json::from_str(&chunk_str)?;
+
+                //Extract the data part from the response
+                let part_text = gemini_response
+                    .candidates
+                    .iter()
+                    .filter(|candidate| candidate.content.role.as_deref() == Some("model"))
+                    .flat_map(|candidate| &candidate.content.parts)
+                    .map(|part| &part.text)
+                    .fold(String::new(), |mut acc, text| {
+                        acc.push_str(text);
+                        acc
+                    });
+
+                //Add the chunk response to output string
+                streamed_response.push_str(&part_text);
+
+                // Debug log each chunk if needed
+                if debug {
+                    info!(
+                        "[debug][Google Gemini] Received response chunk: {:?}",
+                        chunk
+                    );
+                }
+            }
+
+            Ok(streamed_response)
+        } else {
+            let response_status = response.status();
+            let response_txt = response.text().await?;
+            Err(anyhow!(
+                "[allms][Google][{}] Response body: {:#?}",
+                response_status,
+                response_txt
+            )
+            .into())
+        }
+    }
+
+    //Because GeminPro streams data in chunks the extraction of data/text is handled in call_api method. Here we only pass the input forward
+    fn get_data(&self, response_text: &str, _function_call: bool) -> Result<String> {
+        Ok(response_text.to_string())
+    }
+
+    //This function allows to check the rate limits for different models
+    fn get_rate_limit(&self) -> RateLimit {
+        //https://ai.google.dev/models/gemini
+        RateLimit {
+            tpm: 60 * 32_000, // Google only specifies RPM. TPM is calculated from that
+            rpm: 60,
+        }
+    }
+}

--- a/src/llm_models/google.rs
+++ b/src/llm_models/google.rs
@@ -198,7 +198,7 @@ impl LLMModel for GoogleModels {
             GoogleModels::GeminiProVertex => Ok(response_text.to_string()),
             GoogleModels::GeminiPro => {
                 //Convert response to struct representing expected response format
-                let gemini_response: GoogleGeminiProApiResp = serde_json::from_str(&response_text)?;
+                let gemini_response: GoogleGeminiProApiResp = serde_json::from_str(response_text)?;
 
                 //Extract the data part from the response
                 Ok(gemini_response

--- a/src/llm_models/google.rs
+++ b/src/llm_models/google.rs
@@ -162,8 +162,7 @@ impl LLMModel for GoogleModels {
                 "[allms][Google][{}] Response body: {:#?}",
                 response_status,
                 response_txt
-            )
-            .into())
+            ))
         }
     }
 

--- a/src/llm_models/mod.rs
+++ b/src/llm_models/mod.rs
@@ -1,9 +1,11 @@
 pub mod anthropic;
+pub mod google;
 pub mod llm_model;
 pub mod mistral;
 pub mod open_ai;
 
 pub use anthropic::AnthropicModels;
+pub use google::GoogleModels;
 pub use llm_model::LLMModel;
 pub use mistral::MistralModels;
 pub use open_ai::OpenAIModels;


### PR DESCRIPTION
Changes:

- [ ] New `llm_models::GoogleModels` enum with all the LLMModel trait methods implemented
- [ ] For `GoogleModels::GeminProVertex` (via Vertex AI) the code uses streaming and deserializes each response chunk, and for `GoogleModels::GeminPro` (via AI Studio) it just parses the full response
- [ ] New structs in `domains` module to deserialize GeminiPro API response
- [ ] New variables storing urls of Vertex and AI Studio APIs
- [ ] Testing code in `examples/use_completions`, including getting auth token for service ccount