### PR TITLE
Simplify OpenAI Assistant and File constructors

### DIFF
--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -46,8 +46,8 @@ async fn main() -> Result<()> {
     ];
 
     // Extract concert information using Assistant API
-    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4o, &api_key, true)
-        .await?
+    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4o, &api_key)
+        .debug()
         // Constructor defaults to V1
         .version(OpenAIAssistantVersion::V2)
         .set_context(

--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -35,7 +35,10 @@ async fn main() -> Result<()> {
         .map(|s| s.to_string())
         .ok_or_else(|| anyhow!("Failed to extract file name"))?;
 
-    let openai_file = OpenAIFile::new(&file_name, bytes, &api_key, true).await?;
+    let openai_file = OpenAIFile::new(None, &api_key)
+        .debug()
+        .upload(&file_name, bytes)
+        .await?;
 
     let bands_genres = vec![
         ("Metallica", "Metal"),
@@ -59,14 +62,14 @@ async fn main() -> Result<()> {
             "Extract the information requested in the response type from the attached concert information.
             The response should include the genre of the music the 'band' represents.
             The mapping of bands to genres was provided in 'bands_genres' list in a previous message.",
-            &[openai_file.id.clone()],
+            &[openai_file.id.clone().unwrap_or_default()],
         )
         .await?;
 
-    println!("Concert Info: {:?}", concert_info);
+    println!("Concert Info: {:#?}", concert_info);
 
     //Remove the file from OpenAI
-    openai_file.delete_file().await?;
+    openai_file.delete().await?;
 
     Ok(())
 }

--- a/src/assistants/openai/openai_assistant.rs
+++ b/src/assistants/openai/openai_assistant.rs
@@ -42,18 +42,26 @@ pub struct OpenAIAssistant {
 
 impl OpenAIAssistant {
     //Constructor
-    pub async fn new(model: OpenAIModels, open_ai_key: &str, debug: bool) -> Result<Self> {
-        Ok(OpenAIAssistant {
+    pub fn new(model: OpenAIModels, open_ai_key: &str) -> Self {
+        OpenAIAssistant {
             id: None,
             thread_id: None,
             run_id: None,
             model,
             instructions: OPENAI_ASSISTANT_INSTRUCTIONS.to_string(),
-            debug,
+            debug: false,
             api_key: open_ai_key.to_string(),
             // Defaulting to V1 for now
             version: OpenAIAssistantVersion::V1,
-        })
+        }
+    }
+
+    ///
+    /// This method can be used to turn on debug mode for the Assistant
+    ///
+    pub fn debug(mut self) -> Self {
+        self.debug = true;
+        self
     }
 
     ///

--- a/src/assistants/openai/openai_file.rs
+++ b/src/assistants/openai/openai_file.rs
@@ -25,17 +25,14 @@ pub struct OpenAIDFileDeleteResp {
 
 impl OpenAIFile {
     /// Constructor
-    pub fn new(
-        id: Option<String>,
-        open_ai_key: &str,
-    ) -> Self {
+    pub fn new(id: Option<String>, open_ai_key: &str) -> Self {
         OpenAIFile {
             id,
             debug: false,
             api_key: open_ai_key.to_string(),
         }
     }
-    
+
     ///
     /// This method can be used to turn on debug mode for the OpenAIFile struct
     ///
@@ -140,7 +137,9 @@ impl OpenAIFile {
         let file_id = if let Some(id) = &self.id {
             id
         } else {
-            return Err(anyhow!("[OpenAI][File API] Unable to delete file without an ID."))
+            return Err(anyhow!(
+                "[OpenAI][File API] Unable to delete file without an ID."
+            ));
         };
 
         let files_url = format!("https://api.openai.com/v1/files/{}", file_id);


### PR DESCRIPTION
This PR modifies the constructors of `OpenAIAssistant` and `OpenAIFile` structs as they don't have to be async anymore.

Before:
```
    let openai_file = OpenAIFile::new(&file_name, bytes, &api_key, true).await?;
    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4o, &api_key, true)
        .await?
```

After:
```
    let openai_file = OpenAIFile::new(None, &api_key) // Much simplified constructor
        .debug() // Explicit setting of debug mode outside of constructor
        .upload(&file_name, bytes) // dedicated method to upload a file
        .await?;

    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4o, &api_key)
        .debug() // Explicit setting of debug mode outside of constructor
```

This PR also allows us to delete any of the previously uploaded files. The previous constructor was always creating a new file so there was no way to use the struct on an existing file.

Linked issues:
- https://github.com/neferdata/allms/issues/8
- https://github.com/neferdata/allms/issues/22

Please note that the old constructors are still available in the `deprecated` module so this change should not break existing implementations. People that want to use new features will have to upgrade.