### PR TITLE
[Assistants API] GPT4 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allms"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",

--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<()> {
     );
 
     // Extract concert information using Assistant API
-    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4TurboPreview, &api_key)
+    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4Turbo, &api_key)
         .debug()
         // Constructor defaults to V1
         .version(OpenAIAssistantVersion::V2)

--- a/src/llm_models/openai.rs
+++ b/src/llm_models/openai.rs
@@ -339,6 +339,19 @@ impl LLMModel for OpenAIModels {
     }
 }
 
+impl OpenAIModels {
+    // This function checks if a model supports tool use in Assistants API (e.g. file_search)
+    pub fn tools_support(&self) -> bool {
+        match self {
+            OpenAIModels::Gpt3_5Turbo 
+            | OpenAIModels::Gpt4Turbo
+            | OpenAIModels::Gpt4TurboPreview
+            | OpenAIModels::Gpt4o => true,
+            _ => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::llm_models::llm_model::LLMModel;

--- a/src/llm_models/openai.rs
+++ b/src/llm_models/openai.rs
@@ -343,7 +343,7 @@ impl OpenAIModels {
     // This function checks if a model supports tool use in Assistants API (e.g. file_search)
     pub fn tools_support(&self) -> bool {
         match self {
-            OpenAIModels::Gpt3_5Turbo 
+            OpenAIModels::Gpt3_5Turbo
             | OpenAIModels::Gpt4Turbo
             | OpenAIModels::Gpt4TurboPreview
             | OpenAIModels::Gpt4o => true,

--- a/src/llm_models/openai.rs
+++ b/src/llm_models/openai.rs
@@ -342,13 +342,13 @@ impl LLMModel for OpenAIModels {
 impl OpenAIModels {
     // This function checks if a model supports tool use in Assistants API (e.g. file_search)
     pub fn tools_support(&self) -> bool {
-        match self {
+        matches!(
+            self,
             OpenAIModels::Gpt3_5Turbo
-            | OpenAIModels::Gpt4Turbo
-            | OpenAIModels::Gpt4TurboPreview
-            | OpenAIModels::Gpt4o => true,
-            _ => false,
-        }
+                | OpenAIModels::Gpt4Turbo
+                | OpenAIModels::Gpt4TurboPreview
+                | OpenAIModels::Gpt4o
+        )
     }
 }
 


### PR DESCRIPTION
When using GPT4 with Assistants API it is not possible to use tools. We were attaching tools by default which made the API always return an error if GPT4 was selected as model. Now tools are only attached for models that support them.