### PR TITLE
Update slugs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Kamil Litman <kamil@neferdata.com>",
     "Dario Lencina <dario@neferdata.com>",
 ]
-keywords = ["openai", "mistral", "anthropic", "gemini", "assistant"]
+keywords = ["api-bindings", "development-tools", "parsing", "science", "text-processing"]
 description = "One Library to rule them aLLMs"
 license = "MIT"
 repository = "https://github.com/neferdata/allms.git"


### PR DESCRIPTION
> error: failed to publish to registry at https://crates.io/
> 
> Caused by:
>   the remote server responded with an error (status 400 Bad Request): The following category slugs are not currently supported on crates.io: openai, anthropic, mistral, gemini, assistant
> 
>   See https://crates.io/category_slugs for a list of supported slugs.