### PR TITLE
[openai][assistant] Get valid Json answer using Json Schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["api-bindings", "development-tools", "parsing", "science", "text-p
 [dependencies]
 anyhow = "1.0.60"
 env_logger = "0.9.0"
+jsonschema = "=0.15.2"
 log = "0.4.0"
 r2d2 = "0.8.10"
 r2d2_postgres = "0.18.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allms"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",

--- a/examples/use_openai_assistant_json.rs
+++ b/examples/use_openai_assistant_json.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use allms::assistants::{OpenAIAssistant, OpenAIAssistantVersion, OpenAIFile, OpenAIVectorStore};
-use allms::llm_models::OpenAIModels;
+use allms::llm::OpenAIModels;
 
 use anyhow::{anyhow, Result};
 

--- a/examples/use_openai_assistant_json.rs
+++ b/examples/use_openai_assistant_json.rs
@@ -1,0 +1,115 @@
+use std::ffi::OsStr;
+use std::path::Path;
+
+use allms::assistants::{OpenAIAssistant, OpenAIAssistantVersion, OpenAIFile, OpenAIVectorStore};
+use allms::llm_models::OpenAIModels;
+
+use anyhow::{anyhow, Result};
+
+const CONCERT_INFO_SCHEMA: &str = r#"
+{
+    "type": "object",
+    "properties": {
+        "dates": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "band": {
+            "type": "string"
+        },
+        "genre": {
+            "type": "string"
+        },
+        "venue": {
+            "type": "string"
+        },
+        "city": {
+            "type": "string"
+        },
+        "country": {
+            "type": "string"
+        },
+        "ticket_price": {
+            "type": "string"
+        }
+    }
+}
+"#;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::init();
+    let api_key: String = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+    // Read concert file
+    let path = Path::new("metallica.pdf");
+    let bytes = std::fs::read(path)?;
+    let file_name = path
+        .file_name()
+        .and_then(OsStr::to_str)
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("Failed to extract file name"))?;
+
+    let openai_file = OpenAIFile::new(None, &api_key)
+        .debug()
+        .upload(&file_name, bytes)
+        .await?;
+
+    let bands_genres = vec![
+        ("Metallica", "Metal"),
+        ("The Beatles", "Rock"),
+        ("Daft Punk", "Electronic"),
+        ("Miles Davis", "Jazz"),
+        ("Johnny Cash", "Country"),
+    ];
+
+    // Create a Vector Store and assign the file to it
+    let openai_vector_store = OpenAIVectorStore::new(None, "Concerts", &api_key)
+        .debug()
+        .upload(&[openai_file.id.clone().unwrap_or_default()])
+        .await?;
+
+    let status = openai_vector_store.status().await?;
+    println!(
+        "Vector Store: {:?}; Status: {:?}",
+        &openai_vector_store.id, &status
+    );
+
+    let file_count = openai_vector_store.file_count().await?;
+    println!(
+        "Vector Store: {:?}; File count: {:?}",
+        &openai_vector_store.id, &file_count
+    );
+
+    // Extract concert information using Assistant API
+    let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4Turbo, &api_key)
+        .debug()
+        // Constructor defaults to V1
+        .version(OpenAIAssistantVersion::V2)
+        .vector_store(openai_vector_store.clone())
+        .await?
+        .set_context(
+            "bands_genres",
+            &bands_genres
+        )
+        .await?
+        .get_json_answer(
+            "Extract the information requested in the response type from the attached concert information.
+            The response should include the genre of the music the 'band' represents.
+            The mapping of bands to genres was provided in 'bands_genres' list in a previous message.",
+            CONCERT_INFO_SCHEMA,
+            &[],
+        )
+        .await?;
+
+    println!("Concert Info: {:#?}", concert_info);
+
+    //Remove the file from OpenAI
+    openai_file.delete().await?;
+
+    // Delete the Vector Store
+    openai_vector_store.delete().await?;
+
+    Ok(())
+}

--- a/src/assistants/openai/mod.rs
+++ b/src/assistants/openai/mod.rs
@@ -4,4 +4,6 @@ pub mod openai_vector_store;
 
 pub use openai_assistant::{OpenAIAssistant, OpenAIAssistantVersion};
 pub use openai_file::OpenAIFile;
-pub use openai_vector_store::OpenAIVectorStore;
+pub use openai_vector_store::{
+    OpenAIVectorStore, OpenAIVectorStoreFileCounts, OpenAIVectorStoreStatus,
+};

--- a/src/assistants/openai/openai_assistant.rs
+++ b/src/assistants/openai/openai_assistant.rs
@@ -266,9 +266,7 @@ impl OpenAIAssistant {
             .filter(|message| message.role == OpenAIAssistantRole::Assistant)
             .find_map(|message| {
                 message.content.into_iter().find_map(|content| {
-                    content
-                        .text
-                        .and_then(|text| Some(sanitize_json_response(&text.value)))
+                    content.text.map(|text| sanitize_json_response(&text.value))
                 })
             })
             .ok_or(anyhow!("No valid response form OpenAI Assistant found."))

--- a/src/assistants/openai/openai_vector_store.rs
+++ b/src/assistants/openai/openai_vector_store.rs
@@ -349,11 +349,11 @@ struct OpenAIVectorStoreResp {
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct OpenAIVectorStoreFileCounts {
-    in_progress: i32,
-    completed: i32,
-    failed: i32,
-    cancelled: i32,
-    total: i32,
+    pub in_progress: i32,
+    pub completed: i32,
+    pub failed: i32,
+    pub cancelled: i32,
+    pub total: i32,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -376,7 +376,7 @@ struct OpenAIVectorStoreFileBatchResp {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-enum OpenAIVectorStoreFileBatchStatus {
+pub enum OpenAIVectorStoreFileBatchStatus {
     #[serde(rename(deserialize = "in_progress", serialize = "in_progress"))]
     InProgress,
     #[serde(rename(deserialize = "completed", serialize = "completed"))]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -263,3 +263,12 @@ pub struct GoogleGeminiProUsageMetadata {
     #[serde(rename = "totalTokenCount")]
     pub total_token_count: i32,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AllmsError {
+    #[serde(rename = "crate")]
+    pub crate_name: String,
+    pub module: String,
+    pub error_message: String,
+    pub error_detail: String,
+}


### PR DESCRIPTION
Changes:
- [x] New public `get_json_answer` function that works similarly to the existing `get_answer` function, but instead of specifying the type of response it accepts a json_schema that the response must match.
- [x] Tweak to `get_answer` function to simplify schema passed to AI (removing not needed fields).
- [x] Introduction of a `AllmsError` type to facilitate better passing of information in case of errors.
- [x] (bugfix) Unrelated changes to `OpenAIVectorStore` to publicly expose types returned by some already public methods