### PR TITLE
Improved error response propagation

### DIFF
--- a/src/assistants/openai/openai_assistant.rs
+++ b/src/assistants/openai/openai_assistant.rs
@@ -16,7 +16,8 @@ use tokio::time::timeout;
 use crate::assistants::OpenAIVectorStore;
 use crate::constants::{OPENAI_API_URL, OPENAI_ASSISTANT_INSTRUCTIONS};
 use crate::domain::{
-    OpenAIAssistantResp, OpenAIMessageListResp, OpenAIMessageResp, OpenAIRunResp, OpenAIThreadResp,
+    AllmsError, OpenAIAssistantResp, OpenAIMessageListResp, OpenAIMessageResp, OpenAIRunResp,
+    OpenAIThreadResp,
 };
 use crate::enums::{OpenAIAssistantRole, OpenAIRunStatus};
 use crate::llm_models::{LLMModel, OpenAIModels};
@@ -123,11 +124,14 @@ impl OpenAIAssistant {
         //Deserialize the string response into the Assistant object
         let response_deser: OpenAIAssistantResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[OpenAIAssistant] Assistant API response serialization error: {}",
-                    &error
-                );
-                anyhow!("Error: {}", error)
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_assistant".to_string(),
+                    error_message: format!("Assistant API response serialization error: {}", error),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
 
         //Add correct ID to self
@@ -311,11 +315,14 @@ impl OpenAIAssistant {
         //Deserialize the string response into the Thread object
         let response_deser: OpenAIThreadResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[OpenAIAssistant] Thread API response serialization error: {}",
-                    &error
-                );
-                anyhow!("Error: {}", error)
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_assistant".to_string(),
+                    error_message: format!("Thread API response serialization error: {}", error),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
 
         //Add thread_id to self
@@ -366,11 +373,14 @@ impl OpenAIAssistant {
         //Deserialize the string response into the Message object to confirm if there were any errors
         let _response_deser: OpenAIMessageResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[OpenAIAssistant] Messages API response serialization error: {}",
-                    &error
-                );
-                anyhow!("Error: {}", error)
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_assistant".to_string(),
+                    error_message: format!("Messages API response serialization error: {}", error),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
 
         Ok(())
@@ -417,11 +427,14 @@ impl OpenAIAssistant {
         //Deserialize the string response into a vector of OpenAIMessageResp objects
         let response_deser: OpenAIMessageListResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[OpenAIAssistant] Messages API response serialization error: {}",
-                    &error
-                );
-                anyhow!("Error: {}", error)
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_assistant".to_string(),
+                    error_message: format!("Messages API response serialization error: {}", error),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
 
         Ok(response_deser.data)
@@ -477,11 +490,14 @@ impl OpenAIAssistant {
         //Deserialize the string response into the Message object to confirm if there were any errors
         let response_deser: OpenAIRunResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[OpenAIAssistant] Run API response serialization error: {}",
-                    &error
-                );
-                anyhow!("Error: {}", error)
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_assistant".to_string(),
+                    error_message: format!("Run API response serialization error: {}", error),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
 
         //Update run_id
@@ -540,11 +556,14 @@ impl OpenAIAssistant {
         //Deserialize the string response into the Message object to confirm if there were any errors
         let response_deser: OpenAIRunResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[OpenAIAssistant] Run API response serialization error: {}",
-                    &error
-                );
-                anyhow!("Error: {}", error)
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_assistant".to_string(),
+                    error_message: format!("Run API response serialization error: {}", error),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
 
         Ok(response_deser)
@@ -634,14 +653,17 @@ impl OpenAIAssistant {
         //Deserialize the string response into the Assistants object to confirm if there were any errors
         serde_json::from_str::<OpenAIAssistantResp>(&response_text)
             .map_err(|error| {
-                error!(
-                    "[OpenAIAssistant] Vector Store Attach API response serialization error: {}",
-                    &error
-                );
-                anyhow!(
-                    "[OpenAIAssistant] Vector Store Attach API response serialization error: {}",
-                    error
-                )
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_assistant".to_string(),
+                    error_message: format!(
+                        "Vector Store Attach API response serialization error: {}",
+                        error
+                    ),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })
             .map(|_| Ok(()))?
     }

--- a/src/assistants/openai/openai_vector_store.rs
+++ b/src/assistants/openai/openai_vector_store.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::assistants::OpenAIAssistantVersion;
+use crate::domain::AllmsError;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct OpenAIVectorStore {
@@ -77,14 +78,17 @@ impl OpenAIVectorStore {
         //Deserialize the string response into the Assistant object
         let response_deser: OpenAIVectorStoreResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[allms][OpenAI][VectorStore][debug] VectorStore Create API response serialization error: {}",
-                    &error
-                );
-                anyhow!(
-                    "[allms][OpenAI][VectorStore][debug] VectorStore Create API response serialization error: {}",
-                    error
-                )
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_vector_store".to_string(),
+                    error_message: format!(
+                        "VectorStore Create API response serialization error: {}",
+                        error
+                    ),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
 
         //Add correct ID & status to self
@@ -153,17 +157,21 @@ impl OpenAIVectorStore {
         }
 
         //Deserialize & validate the string response
-        serde_json::from_str::<OpenAIVectorStoreFileBatchResp>(&response_text).map_err(|error| {
-            error!(
-                "[allms][OpenAI][VectorStore][debug] VectorStore Batch Upload API response serialization error: {}",
-                &error
-            );
-            anyhow!(
-                "[allms][OpenAI][VectorStore][debug] VectorStore Batch Upload API response serialization error: {}",
-                error
-            )
-        })
-        .map(|_| Ok(()))?
+        serde_json::from_str::<OpenAIVectorStoreFileBatchResp>(&response_text)
+            .map_err(|error| {
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_vector_store".to_string(),
+                    error_message: format!(
+                        "VectorStore Batch Upload API response serialization error: {}",
+                        error
+                    ),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
+            })
+            .map(|_| Ok(()))?
     }
 
     ///
@@ -208,14 +216,17 @@ impl OpenAIVectorStore {
         //Deserialize & validate the string response
         let response_deser: OpenAIVectorStoreResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[allms][OpenAI][VectorStore][debug] VectorStore Status API response serialization error: {}",
-                    &error
-                );
-                anyhow!(
-                    "[allms][OpenAI][VectorStore][debug] VectorStore Status API response serialization error: {}",
-                    error
-                )
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_vector_store".to_string(),
+                    error_message: format!(
+                        "VectorStore Status API response serialization error: {}",
+                        error
+                    ),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
         Ok(response_deser.status)
     }
@@ -262,14 +273,17 @@ impl OpenAIVectorStore {
         //Deserialize & validate the string response
         let response_deser: OpenAIVectorStoreResp =
             serde_json::from_str(&response_text).map_err(|error| {
-                error!(
-                    "[allms][OpenAI][VectorStore][debug] VectorStore Status API response serialization error: {}",
-                    &error
-                );
-                anyhow!(
-                    "[allms][OpenAI][VectorStore][debug] VectorStore Status API response serialization error: {}",
-                    error
-                )
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_vector_store".to_string(),
+                    error_message: format!(
+                        "VectorStore Status API response serialization error: {}",
+                        error
+                    ),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
             })?;
         Ok(response_deser.file_counts)
     }
@@ -314,20 +328,26 @@ impl OpenAIVectorStore {
         }
 
         //Deserialize & validate the string response
-        serde_json::from_str::<OpenAIVectorStoreDeleteResp>(&response_text).map_err(|error| {
-            error!(
-                "[allms][OpenAI][VectorStore][debug] VectorStore Delete API response serialization error: {}",
-                &error
-            );
-            anyhow!(
-                "[allms][OpenAI][VectorStore][debug] VectorStore Delete API response serialization error: {}",
-                error
-            )
-        })
-        .and_then(|response| match response.deleted {
-            true => Ok(()),
-            false => Err(anyhow!("[OpenAIAssistant] VectorStore Delete API failed to delete the store.")),
-        })
+        serde_json::from_str::<OpenAIVectorStoreDeleteResp>(&response_text)
+            .map_err(|error| {
+                let error = AllmsError {
+                    crate_name: "allms".to_string(),
+                    module: "assistants::openai_vector_store".to_string(),
+                    error_message: format!(
+                        "VectorStore Delete API response serialization error: {}",
+                        error
+                    ),
+                    error_detail: response_text,
+                };
+                error!("{:?}", error);
+                anyhow!("{:?}", error)
+            })
+            .and_then(|response| match response.deleted {
+                true => Ok(()),
+                false => Err(anyhow!(
+                    "[OpenAIAssistant] VectorStore Delete API failed to delete the store."
+                )),
+            })
     }
 }
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -263,3 +263,12 @@ pub struct GoogleGeminiProUsageMetadata {
     #[serde(rename = "totalTokenCount")]
     pub total_token_count: i32,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AllmsError {
+    #[serde(rename = "crate")]
+    pub crate_name: String,
+    pub module: String,
+    pub error_message: String,
+    pub error_detail: String,
+}


### PR DESCRIPTION
This PR improves how we propagate errors received from AI APIs. 

Most of these errors were previously passed as serialization. For example, currently in logs we would see something like below that is not very helpful for troubleshooting:
> [2024-07-21T16:42:54Z ERROR allms::assistants::openai::openai_assistant] [OpenAIAssistant] Messages API response serialization error: missing field `id` at line 8 column 1

This PR takes advantage of the recently introduced `AllmsError` struct and passes information about what caused the error but also the response received from AI API. For example:
> [2024-07-21T16:51:42Z ERROR allms::completions] AllmsError { crate_name: "allms", module: "assistants::completions::claude-2.1", error_message: "Completions API response serialization error: missing field `id` at line 1 column 86", error_detail: "{\"type\":\"error\",\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key\"}}" }