### PR TITLE
[Anthropic] Support for `Claude3_5Sonnet`, `Claude3Opus`, `Claude3Sonnet`, and `Claude3Haiku`

### DIFF
--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -40,7 +40,7 @@ async fn main() {
     // Get answer using Anthropic
     let anthropic_api_key: String =
         std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
-    let model = AnthropicModels::Claude2; // Choose the model
+    let model = AnthropicModels::Claude3_5Sonnet; // Choose the model
 
     let anthropic_completion = Completions::new(model, &anthropic_api_key, None, None);
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,6 +8,9 @@ lazy_static! {
 lazy_static! {
     pub(crate) static ref ANTHROPIC_API_URL: String = std::env::var("ANTHROPIC_API_URL")
         .unwrap_or("https://api.anthropic.com/v1/complete".to_string());
+    pub(crate) static ref ANTHROPIC_MESSAGES_API_URL: String =
+        std::env::var("ANTHROPIC_MESSAGES_API_URL")
+            .unwrap_or("https://api.anthropic.com/v1/messages".to_string());
 }
 
 lazy_static! {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -158,6 +158,33 @@ pub struct AnthropicAPICompletionsResponse {
     pub model: String,
 }
 
+//Anthropic API response type format for Messages API
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AnthropicAPIMessagesResponse {
+    pub id: String,
+    #[serde(rename(deserialize = "type", serialize = "type"))]
+    pub request_type: String,
+    pub role: String,
+    pub content: Vec<AnthropicAPIMessagesContent>,
+    pub model: String,
+    pub stop_reason: Option<String>,
+    pub stop_sequence: Option<String>,
+    pub usage: AnthropicAPIMessagesUsage,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AnthropicAPIMessagesContent {
+    #[serde(rename(deserialize = "type", serialize = "type"))]
+    pub content_type: String,
+    pub text: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct AnthropicAPIMessagesUsage {
+    pub input_tokens: i32,
+    pub output_tokens: i32,
+}
+
 //Mistral API response type format for Chat Completions API
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct MistralAPICompletionsResponse {

--- a/src/llm_models/anthropic.rs
+++ b/src/llm_models/anthropic.rs
@@ -5,11 +5,17 @@ use reqwest::{header, Client};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::constants::ANTHROPIC_API_URL;
-use crate::{domain::AnthropicAPICompletionsResponse, llm_models::LLMModel};
+use crate::constants::{ANTHROPIC_API_URL, ANTHROPIC_MESSAGES_API_URL};
+use crate::domain::{AnthropicAPICompletionsResponse, AnthropicAPIMessagesResponse};
+use crate::llm_models::LLMModel;
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum AnthropicModels {
+    Claude3_5Sonnet,
+    Claude3Opus,
+    Claude3Sonnet,
+    Claude3Haiku,
+    // Legacy
     Claude2,
     ClaudeInstant1_2,
 }
@@ -18,21 +24,40 @@ pub enum AnthropicModels {
 impl LLMModel for AnthropicModels {
     fn as_str(&self) -> &'static str {
         match self {
+            AnthropicModels::Claude3_5Sonnet => "claude-3-5-sonnet-20240620",
+            AnthropicModels::Claude3Opus => "claude-3-opus-20240229",
+            AnthropicModels::Claude3Sonnet => "claude-3-sonnet-20240229",
+            AnthropicModels::Claude3Haiku => "claude-3-haiku-20240307",
+            // Legacy
             AnthropicModels::Claude2 => "claude-2.1",
             AnthropicModels::ClaudeInstant1_2 => "claude-instant-1.2",
         }
     }
 
     fn default_max_tokens(&self) -> usize {
-        //This is the max tokens allowed for response and not context as per documentation: https://docs.anthropic.com/claude/reference/input-and-output-sizes
+        // This is the max tokens allowed for response and not context as per documentation: https://docs.anthropic.com/claude/reference/input-and-output-sizes
         match self {
+            AnthropicModels::Claude3_5Sonnet => 4_096, // 8192 output tokens is in beta and requires the header anthropic-beta: max-tokens-3-5-sonnet-2024-07-15. If the header is not specified, the limit is 4096 tokens. (Source: https://docs.anthropic.com/en/docs/about-claude/models)
+            AnthropicModels::Claude3Opus => 4_096,
+            AnthropicModels::Claude3Sonnet => 4_096,
+            AnthropicModels::Claude3Haiku => 4_096,
+            // Legacy
             AnthropicModels::Claude2 => 4_096,
             AnthropicModels::ClaudeInstant1_2 => 4_096,
         }
     }
 
     fn get_endpoint(&self) -> String {
-        ANTHROPIC_API_URL.to_string()
+        match self {
+            AnthropicModels::Claude3_5Sonnet
+            | AnthropicModels::Claude3Opus
+            | AnthropicModels::Claude3Sonnet
+            | AnthropicModels::Claude3Haiku => ANTHROPIC_MESSAGES_API_URL.to_string(),
+            // Legacy
+            AnthropicModels::Claude2 | AnthropicModels::ClaudeInstant1_2 => {
+                ANTHROPIC_API_URL.to_string()
+            }
+        }
     }
 
     //This method prepares the body of the API call for different models
@@ -46,7 +71,8 @@ impl LLMModel for AnthropicModels {
     ) -> serde_json::Value {
         let schema_string = serde_json::to_string(json_schema).unwrap_or_default();
         let base_instructions = self.get_base_instructions(Some(function_call));
-        json!({
+
+        let completions_body = json!({
             "model": self.as_str(),
             "max_tokens_to_sample": max_tokens,
             "temperature": temperature,
@@ -58,7 +84,31 @@ impl LLMModel for AnthropicModels {
                 {instructions}
                 \n\nAssistant:",
             ),
-        })
+        });
+
+        let message_body = json!({
+            "model": self.as_str(),
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "messages": [{
+                "role": "user",
+                "content": format!(
+                    "{base_instructions}\n\n
+                    Output Json schema:\n
+                    {schema_string}\n\n
+                    {instructions}"
+                )
+            }],
+        });
+
+        match self {
+            AnthropicModels::Claude3_5Sonnet
+            | AnthropicModels::Claude3Opus
+            | AnthropicModels::Claude3Sonnet
+            | AnthropicModels::Claude3Haiku => message_body,
+            // Legacy
+            AnthropicModels::Claude2 | AnthropicModels::ClaudeInstant1_2 => completions_body,
+        }
     }
     /*
      * This function leverages Anthropic API to perform any query as per the provided body.
@@ -105,10 +155,34 @@ impl LLMModel for AnthropicModels {
     //This method attempts to convert the provided API response text into the expected struct and extracts the data from the response
     fn get_data(&self, response_text: &str, _function_call: bool) -> Result<String> {
         //Convert API response to struct representing expected response format
-        let completions_response: AnthropicAPICompletionsResponse =
-            serde_json::from_str(response_text)?;
+        match self {
+            AnthropicModels::Claude3_5Sonnet
+            | AnthropicModels::Claude3Opus
+            | AnthropicModels::Claude3Sonnet
+            | AnthropicModels::Claude3Haiku => {
+                let messages_response: AnthropicAPIMessagesResponse =
+                    serde_json::from_str(response_text)?;
 
-        //Return completions text
-        Ok(completions_response.completion)
+                let assistant_response = messages_response
+                    .content
+                    .iter()
+                    .map(|item| &item.text)
+                    .fold(String::new(), |mut acc, text| {
+                        acc.push_str(text);
+                        acc
+                    });
+
+                //Return completions text
+                Ok(assistant_response)
+            }
+            // Legacy
+            AnthropicModels::Claude2 | AnthropicModels::ClaudeInstant1_2 => {
+                let completions_response: AnthropicAPICompletionsResponse =
+                    serde_json::from_str(response_text)?;
+
+                //Return completions text
+                Ok(completions_response.completion)
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR includes:
- [ ] Support for newest Anthropic models `Claude3_5Sonnet`, `Claude3Opus`, `Claude3Sonnet`, `Claude3Haiku`
- [ ] Support of `v1/messages` API which needs to be used with the new models instead of the `v1/completions` API