### PR TITLE
[minor] `llm` alias for `llm_models` module

### DIFF
--- a/examples/use_completions.rs
+++ b/examples/use_completions.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use allms::{
-    llm_models::{AnthropicModels, GoogleModels, MistralModels, OpenAIModels},
+    llm::{AnthropicModels, GoogleModels, MistralModels, OpenAIModels},
     Completions,
 };
 

--- a/examples/use_completions_vertex.rs
+++ b/examples/use_completions_vertex.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use yup_oauth2::{read_service_account_key, ServiceAccountAuthenticator};
 
-use allms::{llm_models::GoogleModels, Completions};
+use allms::{llm::GoogleModels, Completions};
 
 #[derive(Deserialize, Serialize, JsonSchema, Debug, Clone)]
 struct TranslationResponse {

--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -2,7 +2,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 use allms::assistants::{OpenAIAssistant, OpenAIAssistantVersion, OpenAIFile, OpenAIVectorStore};
-use allms::llm_models::OpenAIModels;
+use allms::llm::OpenAIModels;
 
 use anyhow::{anyhow, Result};
 use schemars::JsonSchema;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod constants;
 mod domain;
 mod enums;
 pub mod llm_models;
+pub use llm_models as llm;
 mod utils;
 
 #[allow(deprecated)]

--- a/src/llm_models/mod.rs
+++ b/src/llm_models/mod.rs
@@ -7,5 +7,6 @@ pub mod openai;
 pub use anthropic::AnthropicModels;
 pub use google::GoogleModels;
 pub use llm_model::LLMModel;
+pub use llm_model::LLMModel as LLM;
 pub use mistral::MistralModels;
 pub use openai::OpenAIModels;


### PR DESCRIPTION
This is a minor change, but the name of the module has been annoying me. LLM already means Large Language **Model** so adding another 'model' after it is just bad grammar. 