### PR TITLE
[BugFix] Filtering of response messages was displaying error message even if there was a valid response

### DIFF
--- a/src/assistants/openai/openai_assistant.rs
+++ b/src/assistants/openai/openai_assistant.rs
@@ -275,7 +275,7 @@ impl OpenAIAssistant {
                         .map(|text| sanitize_json_response(&text.value))
                 })
             })
-            .ok_or({
+            .ok_or_else(|| {
                 let error = AllmsError {
                     crate_name: "allms".to_string(),
                     module: "assistants::openai_assistant".to_string(),


### PR DESCRIPTION
Fix was a simple change from `ok_or` to `ok_or_else`.

As per ChatGPT:
> The behavior you've observed suggests that there was an issue with how ok_or and ok_or_else were being used or perceived. Understanding the distinction between these two methods and their execution timing can clarify why switching to ok_or_else resolved the issue.
> 
> ok_or vs. ok_or_else
> ok_or: This method is eager, meaning the error argument is evaluated immediately, regardless of whether it's needed. This means the error block code executes every time ok_or is called, and only after this execution does it check whether to use the evaluated error or the value from the Option.
> 
> ok_or_else: This method is lazy and only evaluates the error block when needed, i.e., when the Option is None. This prevents unnecessary computation or side effects if the Option is actually Some(value).