### PR TITLE
Custom OpenAI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This Rust library is specialized in providing type-safe interactions with APIs o
 ### Foundational Models
 OpenAI:
 - APIs: Chat Completions, Function Calling, Assistants (v1 & v2), Files, Vector Stores, Tools (file_search)
-- Models: GPT-4o, GPT-4, GPT-4 32k, GPT-4 Turbo, GPT-3.5 Turbo, GPT-3.5 Turbo 16k
+- Models: GPT-4o, GPT-4, GPT-4 32k, GPT-4 Turbo, GPT-3.5 Turbo, GPT-3.5 Turbo 16k, fine-tuned models (via `Custom` variant)
 
 Anthropic:
 - APIs: Messages, Text Completions

--- a/src/llm_models/anthropic.rs
+++ b/src/llm_models/anthropic.rs
@@ -9,7 +9,7 @@ use crate::constants::{ANTHROPIC_API_URL, ANTHROPIC_MESSAGES_API_URL};
 use crate::domain::{AnthropicAPICompletionsResponse, AnthropicAPIMessagesResponse};
 use crate::llm_models::LLMModel;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 pub enum AnthropicModels {
     Claude3_5Sonnet,
     Claude3Opus,
@@ -22,7 +22,7 @@ pub enum AnthropicModels {
 
 #[async_trait(?Send)]
 impl LLMModel for AnthropicModels {
-    fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> &str {
         match self {
             AnthropicModels::Claude3_5Sonnet => "claude-3-5-sonnet-20240620",
             AnthropicModels::Claude3Opus => "claude-3-opus-20240229",

--- a/src/llm_models/google.rs
+++ b/src/llm_models/google.rs
@@ -11,7 +11,7 @@ use crate::domain::{GoogleGeminiProApiResp, RateLimit};
 use crate::llm_models::LLMModel;
 use crate::utils::sanitize_json_response;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 //Google docs: https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/gemini
 pub enum GoogleModels {
     GeminiPro,
@@ -27,7 +27,7 @@ pub enum GoogleModels {
 
 #[async_trait(?Send)]
 impl LLMModel for GoogleModels {
-    fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> &str {
         match self {
             GoogleModels::GeminiPro | GoogleModels::GeminiProVertex => "gemini-pro",
             GoogleModels::Gemini1_5Pro | GoogleModels::Gemini1_5ProVertex => "gemini-1.5-pro",

--- a/src/llm_models/llm_model.rs
+++ b/src/llm_models/llm_model.rs
@@ -9,7 +9,7 @@ use crate::domain::RateLimit;
 #[async_trait(?Send)]
 pub trait LLMModel {
     ///Converts each item in the model enum into its string representation
-    fn as_str(&self) -> &'static str;
+    fn as_str(&self) -> &str;
     ///Returns an instance of the enum based on the provided string representation of name
     fn try_from_str(name: &str) -> Option<Self>
     where

--- a/src/llm_models/mistral.rs
+++ b/src/llm_models/mistral.rs
@@ -10,7 +10,7 @@ use crate::domain::{MistralAPICompletionsResponse, RateLimit};
 use crate::llm_models::LLMModel;
 use crate::utils::sanitize_json_response;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
 //Mistral docs: https://docs.mistral.ai/platform/endpoints
 pub enum MistralModels {
     MistralLarge,
@@ -26,7 +26,7 @@ pub enum MistralModels {
 
 #[async_trait(?Send)]
 impl LLMModel for MistralModels {
-    fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> &str {
         match self {
             MistralModels::MistralLarge => "mistral-large-latest",
             MistralModels::MistralNemo => "open-mistral-nemo",


### PR DESCRIPTION
This PR introduces support of `Custom` model in the `OpenAIModels` enum. This is useful if someone is using fine-tuned models or if they are using OpenAI via Azure where the model name is the deployment name.