### PR TITLE
Azure OpenAI API version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allms"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ OpenAI:
 - APIs: Chat Completions, Function Calling, Assistants (v1 & v2), Files, Vector Stores, Tools (file_search)
 - Models: o1 Preview, o1 Mini (Chat Completions only), GPT-4o, GPT-4, GPT-4 32k, GPT-4 Turbo, GPT-3.5 Turbo, GPT-3.5 Turbo 16k, fine-tuned models (via `Custom` variant)
 
-Azure OpenAI
+Azure OpenAI:
 - APIs: Assistants, Files, Vector Stores, Tools
+    - API version can be set using `AzureVersion` variant
 - Models: as per model deployments in Azure OpenAI Studio
 
 Anthropic:
@@ -37,7 +38,7 @@ Google Vertex AI / AI Studio:
 
 ### Prerequisites
 - OpenAI: API key (passed in model constructor)
-- Azure OpenAI: environment variable `OPENAI_API_URL` set to your Azure OpenAI resource endpoint. Model deployment names in Azure OpenAI Stuido need to match `OpenAIModels::as_str()`
+- Azure OpenAI: environment variable `OPENAI_API_URL` set to your Azure OpenAI resource endpoint. If using custom model deployment names in Azure OpenAI Studio please use the `Custom` variant of `OpenAIModels`
 - Anthropic: API key (passed in model constructor)
 - Mistral: API key (passed in model constructor)
 - Google AI Studio: API key (passed in model constructor)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Azure OpenAI:
 - APIs: Assistants, Files, Vector Stores, Tools
     - API version can be set using `AzureVersion` variant
 - Models: as per model deployments in Azure OpenAI Studio
+    - If using custom model deployment names please use the `Custom` variant of `OpenAIModels`
 
 Anthropic:
 - APIs: Messages, Text Completions
@@ -38,7 +39,7 @@ Google Vertex AI / AI Studio:
 
 ### Prerequisites
 - OpenAI: API key (passed in model constructor)
-- Azure OpenAI: environment variable `OPENAI_API_URL` set to your Azure OpenAI resource endpoint. If using custom model deployment names in Azure OpenAI Studio please use the `Custom` variant of `OpenAIModels`
+- Azure OpenAI: environment variable `OPENAI_API_URL` set to your Azure OpenAI resource endpoint. Endpoint key passed in constructor
 - Anthropic: API key (passed in model constructor)
 - Mistral: API key (passed in model constructor)
 - Google AI Studio: API key (passed in model constructor)

--- a/examples/use_openai_assistant_azure.rs
+++ b/examples/use_openai_assistant_azure.rs
@@ -37,7 +37,9 @@ async fn main() -> Result<()> {
     // Set API version to Azure
     let openai_file = OpenAIFile::new(None, &api_key)
         .debug()
-        .version(OpenAIAssistantVersion::Azure)
+        .version(OpenAIAssistantVersion::AzureVersion {
+            version: "2024-06-01".to_string(),
+        })
         .upload(&file_name, bytes)
         .await?;
 
@@ -52,7 +54,9 @@ async fn main() -> Result<()> {
     // Create a Vector Store and assign the file to it
     let openai_vector_store = OpenAIVectorStore::new(None, "Concerts", &api_key)
         .debug()
-        .version(OpenAIAssistantVersion::Azure)
+        .version(OpenAIAssistantVersion::AzureVersion {
+            version: "2024-06-01".to_string(),
+        })
         .upload(&[openai_file.id.clone().unwrap_or_default()])
         .await?;
 
@@ -72,7 +76,7 @@ async fn main() -> Result<()> {
     let concert_info = OpenAIAssistant::new(OpenAIModels::Gpt4o, &api_key)
         .debug()
         // Constructor defaults to V1
-        .version(OpenAIAssistantVersion::Azure)
+        .version(OpenAIAssistantVersion::AzureVersion  { version: "2024-06-01".to_string(), })
         .vector_store(openai_vector_store.clone())
         .await?
         .set_context(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -58,3 +58,5 @@ pub(crate) const OPENAI_ASSISTANT_INSTRUCTIONS: &str = r#"You are a computer fun
 3: Prepare response using your language model based on the user messages and provided files.
 4: Respond ONLY with properly formatted data portion of a Json. No other words or text, only valid Json in your answers. 
 "#;
+
+pub(crate) const DEFAULT_AZURE_VERSION: &str = "2024-06-01";


### PR DESCRIPTION
This PR allows users to define which version of the Azure OpenAI API they are using. (Currently the version was hard-coded.) It also changes how the default version is being handled, which was move to constant instead of being directly hard-coded.

This PR should be backwards compatible as it introduces a new variant of the version enum.