### PR TITLE
[OpenAI][Assistants] Customizable polling frequency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allms"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",

--- a/examples/use_openai_assistant.rs
+++ b/examples/use_openai_assistant.rs
@@ -71,6 +71,7 @@ async fn main() -> Result<()> {
         .debug()
         // Constructor defaults to V1
         .version(OpenAIAssistantVersion::V2)
+        .poll_interval(5) // Set response polling to every 5 sec
         .vector_store(openai_vector_store.clone())
         .await?
         .set_context(

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -84,4 +84,6 @@ pub(crate) const OPENAI_ASSISTANT_INSTRUCTIONS: &str = r#"You are a computer fun
 4: Respond ONLY with properly formatted data portion of a Json. No other words or text, only valid Json in your answers. 
 "#;
 
+pub(crate) const OPENAI_ASSISTANT_POLL_FREQ: usize = 10;
+
 pub(crate) const DEFAULT_AZURE_VERSION: &str = "2024-06-01";


### PR DESCRIPTION
For OpenAI Assistants API the crate was hardcoded to check for Assistants response every 10 sec. This PR introduces the ability to customize this frequency with a new `poll_interval` method.