### PR TITLE
[bugfix] Azure `properties` & `items` wrappers cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allms"
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",

--- a/src/llm_models/openai.rs
+++ b/src/llm_models/openai.rs
@@ -9,7 +9,7 @@ use crate::{
     constants::{OPENAI_API_URL, OPENAI_BASE_INSTRUCTIONS, OPENAI_FUNCTION_INSTRUCTIONS},
     domain::{OpenAPIChatResponse, OpenAPICompletionsResponse, RateLimit},
     llm_models::LLMModel,
-    utils::{map_to_range, remove_json_wrapper, remove_properties_wrapper},
+    utils::{map_to_range, remove_json_wrapper, remove_schema_wrappers},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
@@ -526,7 +526,7 @@ impl LLMModel for OpenAIModels {
     // OpenAI models, especially on Azure, may return JSON with additional properties wrapper. This function removes it.
     fn sanitize_json_response(&self, json_response: &str) -> String {
         let without_wrapper = remove_json_wrapper(json_response);
-        remove_properties_wrapper(&without_wrapper)
+        remove_schema_wrappers(&without_wrapper)
     }
 }
 

--- a/src/llm_models/openai.rs
+++ b/src/llm_models/openai.rs
@@ -9,7 +9,7 @@ use crate::{
     constants::{OPENAI_API_URL, OPENAI_BASE_INSTRUCTIONS, OPENAI_FUNCTION_INSTRUCTIONS},
     domain::{OpenAPIChatResponse, OpenAPICompletionsResponse, RateLimit},
     llm_models::LLMModel,
-    utils::map_to_range,
+    utils::{map_to_range, remove_json_wrapper, remove_properties_wrapper},
 };
 
 #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
@@ -521,6 +521,12 @@ impl LLMModel for OpenAIModels {
         let min = 0u32;
         let max = 2u32;
         map_to_range(min, max, relative_temp)
+    }
+
+    // OpenAI models, especially on Azure, may return JSON with additional properties wrapper. This function removes it.
+    fn sanitize_json_response(&self, json_response: &str) -> String {
+        let without_wrapper = remove_json_wrapper(json_response);
+        remove_properties_wrapper(&without_wrapper)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -592,8 +592,16 @@ mod tests {
     // Tests for remove_properties_wrapper
     #[test]
     fn test_remove_schema_wrappers_with_wrapper() {
-        let input = r#"{"properties": {"name": "John", "age": 30}}"#;
-        let expected = r#"{"name":"John","age":30}"#;
+        let input = r#"{
+            "properties": {
+                "name": "John",
+                "age": 30
+            }
+        }"#;
+        let expected = r#"{
+            "name": "John",
+            "age": 30
+        }"#;
         let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
@@ -607,7 +615,10 @@ mod tests {
 
     #[test]
     fn test_remove_schema_wrappers_without_wrapper() {
-        let input = r#"{"name": "John", "age": 30}"#;
+        let input = r#"{
+            "name": "John",
+            "age": 30
+        }"#;
         let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
@@ -621,8 +632,22 @@ mod tests {
 
     #[test]
     fn test_remove_schema_wrappers_with_nested_structure() {
-        let input = r#"{"properties": {"user": {"properties": {"name": "John", "age": 30}}}}"#;
-        let expected = r#"{"user":{"name":"John","age":30}}"#;
+        let input = r#"{
+            "properties": {
+                "user": {
+                    "properties": {
+                        "name": "John",
+                        "age": 30
+                    }
+                }
+            }
+        }"#;
+        let expected = r#"{
+            "user": {
+                "name": "John",
+                "age": 30
+            }
+        }"#;
         let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
@@ -646,8 +671,14 @@ mod tests {
 
     #[test]
     fn test_remove_schema_wrappers_with_array() {
-        let input = r#"{"properties": {"items": [1, 2, 3]}}"#;
-        let expected = r#"{"items":[1,2,3]}"#;
+        let input = r#"{
+            "properties": {
+                "items": [1, 2, 3]
+            }
+        }"#;
+        let expected = r#"{
+            "items": [1, 2, 3]
+        }"#;
         let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
@@ -661,8 +692,40 @@ mod tests {
 
     #[test]
     fn test_remove_schema_wrappers_with_complex_structure() {
-        let input = r#"{"properties": {"responses": {"properties": {"items": [{"confidence": 100, "source": "test", "value": {"date": "2024-03-20", "post": "test", "check": false, "url": "https://example.com"}}]}}}}"#;
-        let expected = r#"{"responses":[{"confidence":100,"source":"test","value":{"date":"2024-03-20","post":"test","check":false,"url":"https://example.com"}}]}"#;
+        let input = r#"{
+            "properties": {
+                "responses": {
+                    "properties": {
+                        "items": [
+                            {
+                                "confidence": 100,
+                                "source": "test",
+                                "value": {
+                                    "date": "2024-03-20",
+                                    "post": "test",
+                                    "check": false,
+                                    "url": "https://example.com"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }"#;
+        let expected = r#"{
+            "responses": [
+                {
+                    "confidence": 100,
+                    "source": "test",
+                    "value": {
+                        "date": "2024-03-20",
+                        "post": "test",
+                        "check": false,
+                        "url": "https://example.com"
+                    }
+                }
+            ]
+        }"#;
         let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,18 +51,7 @@ pub(crate) fn remove_think_reasoner_wrapper(json_response: &str) -> String {
 
 /// Removes the properties wrapper from JSON data if it exists
 pub fn remove_properties_wrapper(json_data: &str) -> String {
-    // First clean up the debug representation
-    let cleaned = json_data
-        .replace("Object {", "{")
-        .replace("Array [", "[")
-        .replace("Number(", "")
-        .replace("String(", "")
-        .replace("Bool(", "")
-        .replace(")", "")
-        .replace("\\\"", "\"")
-        .replace("\\\\", "\\");
-
-    match serde_json::from_str::<serde_json::Value>(&cleaned) {
+    match serde_json::from_str::<serde_json::Value>(&json_data) {
         Ok(value) => {
             let processed_value = process_value(value);
             processed_value.to_string()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -107,7 +107,6 @@ fn remove_items_wrappers(value: serde_json::Value) -> serde_json::Value {
                         if inner_obj.len() == 1 {
                             if let Some(items) = inner_obj.get("items") {
                                 if items.is_array() {
-                                    println!("Found items array in named field '{}'", k);
                                     return (k, items.clone());
                                 }
                             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,35 +49,79 @@ pub(crate) fn remove_think_reasoner_wrapper(json_response: &str) -> String {
     re.replace_all(json_response, "").to_string()
 }
 
-/// Removes the properties wrapper from JSON data if it exists
-pub fn remove_properties_wrapper(json_data: &str) -> String {
+/// Removes schema wrappers (properties and items) from JSON data if they exist
+pub fn remove_schema_wrappers(json_data: &str) -> String {
     match serde_json::from_str::<serde_json::Value>(json_data) {
         Ok(value) => {
-            let processed_value = process_value(value);
+            // First remove properties wrappers
+            let processed_value = remove_properties_wrappers(value);
+            // Then handle items wrappers
+            let processed_value = remove_items_wrappers(processed_value);
             processed_value.to_string()
         }
         Err(_) => json_data.to_string(),
     }
 }
 
-fn process_value(value: serde_json::Value) -> serde_json::Value {
+fn remove_properties_wrappers(value: serde_json::Value) -> serde_json::Value {
     match value {
         serde_json::Value::Object(mut obj) => {
-            // If this object has a "properties" field, use its value
-            if let Some(properties) = obj.remove("properties") {
-                process_value(properties)
-            } else {
-                // Process all fields recursively
-                let processed_obj: serde_json::Map<_, _> = obj
-                    .into_iter()
-                    .map(|(k, v)| (k, process_value(v)))
-                    .collect();
-                serde_json::Value::Object(processed_obj)
+            // Check if this is a wrapper object (has only one field)
+            if obj.len() == 1 {
+                // Check for properties wrapper
+                if let Some(properties) = obj.remove("properties") {
+                    if properties.is_object() {
+                        return remove_properties_wrappers(properties);
+                    }
+                }
             }
+
+            // Process all fields recursively
+            let processed_obj: serde_json::Map<_, _> = obj
+                .into_iter()
+                .map(|(k, v)| (k, remove_properties_wrappers(v)))
+                .collect();
+            serde_json::Value::Object(processed_obj)
         }
         serde_json::Value::Array(arr) => {
             // Process array elements recursively
-            serde_json::Value::Array(arr.into_iter().map(process_value).collect())
+            serde_json::Value::Array(arr.into_iter().map(remove_properties_wrappers).collect())
+        }
+        // For other types (string, number, bool, null), return as is
+        other => other,
+    }
+}
+
+fn remove_items_wrappers(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(obj) => {
+            // First process all fields recursively
+            let processed_obj: serde_json::Map<_, _> = obj
+                .into_iter()
+                .map(|(k, v)| {
+                    // Process the value recursively first
+                    let processed_v = remove_items_wrappers(v);
+                    // If this is a named field and its value is an object with a single "items" field that's an array,
+                    // return the array directly
+                    if let serde_json::Value::Object(inner_obj) = &processed_v {
+                        if inner_obj.len() == 1 {
+                            if let Some(items) = inner_obj.get("items") {
+                                if items.is_array() {
+                                    println!("Found items array in named field '{}'", k);
+                                    return (k, items.clone());
+                                }
+                            }
+                        }
+                    }
+                    (k, processed_v)
+                })
+                .collect();
+
+            serde_json::Value::Object(processed_obj)
+        }
+        serde_json::Value::Array(arr) => {
+            // Process array elements recursively
+            serde_json::Value::Array(arr.into_iter().map(remove_items_wrappers).collect())
         }
         // For other types (string, number, bool, null), return as is
         other => other,
@@ -155,7 +199,7 @@ mod tests {
     use crate::llm_models::OpenAIModels;
     use crate::utils::{
         fix_value_schema, get_tokenizer, get_type_schema, map_to_range, map_to_range_f32,
-        remove_properties_wrapper, remove_think_reasoner_wrapper,
+        remove_schema_wrappers, remove_think_reasoner_wrapper,
     };
 
     #[derive(JsonSchema, Serialize, Deserialize)]
@@ -404,7 +448,7 @@ mod tests {
         let mut schema = RootSchema {
             schema: SchemaObject {
                 object: Some(Box::new(ObjectValidation {
-                    properties: std::collections::BTreeMap::new(), // Empty properties
+                    properties: std::collections::BTreeMap::new(),
                     ..Default::default()
                 })),
                 ..Default::default()
@@ -548,10 +592,10 @@ mod tests {
 
     // Tests for remove_properties_wrapper
     #[test]
-    fn test_remove_properties_wrapper_with_wrapper() {
+    fn test_remove_schema_wrappers_with_wrapper() {
         let input = r#"{"properties": {"name": "John", "age": 30}}"#;
         let expected = r#"{"name":"John","age":30}"#;
-        let result = remove_properties_wrapper(input);
+        let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
         let result_value: Value = serde_json::from_str(&result).unwrap();
@@ -563,9 +607,9 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_properties_wrapper_without_wrapper() {
+    fn test_remove_schema_wrappers_without_wrapper() {
         let input = r#"{"name": "John", "age": 30}"#;
-        let result = remove_properties_wrapper(input);
+        let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
         let result_value: Value = serde_json::from_str(&result).unwrap();
@@ -577,10 +621,10 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_properties_wrapper_with_nested_structure() {
+    fn test_remove_schema_wrappers_with_nested_structure() {
         let input = r#"{"properties": {"user": {"properties": {"name": "John", "age": 30}}}}"#;
         let expected = r#"{"user":{"name":"John","age":30}}"#;
-        let result = remove_properties_wrapper(input);
+        let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
         let result_value: Value = serde_json::from_str(&result).unwrap();
@@ -592,9 +636,9 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_properties_wrapper_with_invalid_json() {
+    fn test_remove_schema_wrappers_with_invalid_json() {
         let input = "invalid json";
-        let result = remove_properties_wrapper(input);
+        let result = remove_schema_wrappers(input);
         assert_eq!(
             result, input,
             "Should return original string for invalid JSON"
@@ -602,10 +646,10 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_properties_wrapper_with_array() {
+    fn test_remove_schema_wrappers_with_array() {
         let input = r#"{"properties": {"items": [1, 2, 3]}}"#;
         let expected = r#"{"items":[1,2,3]}"#;
-        let result = remove_properties_wrapper(input);
+        let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
         let result_value: Value = serde_json::from_str(&result).unwrap();
@@ -617,10 +661,10 @@ mod tests {
     }
 
     #[test]
-    fn test_remove_properties_wrapper_with_complex_structure() {
-        let input = r#"{"properties": {"responses": {"properties": {"items": [{"confidence": 100, "source": "test", "value": {"date": "2024-03-20", "post": "test", "tariffs": false, "url": "https://example.com"}}]}}}}"#;
-        let expected = r#"{"responses":{"items":[{"confidence":100,"source":"test","value":{"date":"2024-03-20","post":"test","tariffs":false,"url":"https://example.com"}}]}}"#;
-        let result = remove_properties_wrapper(input);
+    fn test_remove_schema_wrappers_with_complex_structure() {
+        let input = r#"{"properties": {"responses": {"properties": {"items": [{"confidence": 100, "source": "test", "value": {"date": "2024-03-20", "post": "test", "check": false, "url": "https://example.com"}}]}}}}"#;
+        let expected = r#"{"responses":[{"confidence":100,"source":"test","value":{"date":"2024-03-20","post":"test","check":false,"url":"https://example.com"}}]}"#;
+        let result = remove_schema_wrappers(input);
 
         // Parse both strings into Value to compare the actual data structure
         let result_value: Value = serde_json::from_str(&result).unwrap();
@@ -628,6 +672,81 @@ mod tests {
         assert_eq!(
             result_value, expected_value,
             "Should handle complex nested structures"
+        );
+    }
+
+    #[test]
+    fn test_remove_schema_wrappers_with_items() {
+        // Test case 1: items in a named field
+        let input = r#"{
+            "properties": {
+                "responses": {
+                    "items": [
+                        {"id": 1},
+                        {"id": 2}
+                    ]
+                }
+            }
+        }"#;
+        let expected = r#"{
+            "responses": [
+                {"id": 1},
+                {"id": 2}
+            ]
+        }"#;
+
+        let result = remove_schema_wrappers(input);
+        let result_value: Value = serde_json::from_str(&result).unwrap();
+        let expected_value: Value = serde_json::from_str(expected).unwrap();
+        assert_eq!(
+            result_value, expected_value,
+            "Should remove items wrapper when it's in a named field"
+        );
+
+        // Test case 2: items in an unnamed (top-level) object
+        let input = r#"{
+            "items": [
+                {"id": 1},
+                {"id": 2}
+            ]
+        }"#;
+        let expected = r#"{
+            "items": [
+                {"id": 1},
+                {"id": 2}
+            ]
+        }"#;
+
+        let result = remove_schema_wrappers(input);
+        let result_value: Value = serde_json::from_str(&result).unwrap();
+        let expected_value: Value = serde_json::from_str(expected).unwrap();
+        assert_eq!(
+            result_value, expected_value,
+            "Should preserve items when it's in an unnamed object"
+        );
+
+        // Test case 3: items as one of multiple fields
+        let input = r#"{
+            "properties": {
+                "data": {
+                    "items": [1, 2, 3],
+                    "count": 3
+                }
+            }
+        }"#;
+        let expected = r#"{
+            "data": {
+                "items": [1, 2, 3],
+                "count": 3
+            }
+        }"#;
+
+        let result = remove_schema_wrappers(input);
+        let result_value: Value = serde_json::from_str(&result).unwrap();
+        let expected_value: Value = serde_json::from_str(expected).unwrap();
+        assert_eq!(
+            result_value, expected_value,
+            "Should preserve items when it's not the only field"
         );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -51,7 +51,7 @@ pub(crate) fn remove_think_reasoner_wrapper(json_response: &str) -> String {
 
 /// Removes the properties wrapper from JSON data if it exists
 pub fn remove_properties_wrapper(json_data: &str) -> String {
-    match serde_json::from_str::<serde_json::Value>(&json_data) {
+    match serde_json::from_str::<serde_json::Value>(json_data) {
         Ok(value) => {
             let processed_value = process_value(value);
             processed_value.to_string()


### PR DESCRIPTION
In some tests I observed that Azure OpenAI has a tendency to include `properties` and `items` wrappers as part of the response (where it was just sent as part of a valid schema definition). This PR removes that.