### PR TITLE
[bugfix] Google env vars separation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allms"
-version = "0.20.0"
+version = "0.20.1"
 edition = "2021"
 authors = [
     "Kamil Litman <kamil@neferdata.com>",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -32,6 +32,9 @@ lazy_static! {
 
         format!("https://{region}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{region}/endpoints")
     };
+}
+
+lazy_static! {
     pub(crate) static ref GOOGLE_GEMINI_API_URL: String = std::env::var("GOOGLE_GEMINI_API_URL")
         .unwrap_or("https://generativelanguage.googleapis.com/v1/models".to_string());
     pub(crate) static ref GOOGLE_GEMINI_BETA_API_URL: String =


### PR DESCRIPTION
Currently, when using Google Gemini, environment variables for both Studio and Vertex are loaded on the same lazy_static block. But if a user only wants to use Studio they shouldn't need to have the Vertex vars defined. Separating these into separate blocks addresses the problem as only vars that are used get loaded.